### PR TITLE
handle response and data separately

### DIFF
--- a/src/browser/get.js
+++ b/src/browser/get.js
@@ -1,27 +1,13 @@
-import { makeUrl, parseHeaders } from "../template/help";
+import { makeUrl, parseHeaders, handleResponse } from "../template/help";
 
 export default async function get(chunks, ...interpolations) {
   const url = makeUrl(chunks, interpolations);
   const { headers, pureUrl } = parseHeaders(url);
 
-  const startFetch = await fetch(pureUrl, {
+  const response = await fetch(pureUrl, {
     method: "GET",
     headers: headers,
   });
 
-  let data = {
-    data: null,
-    statusText: startFetch.statusText,
-    status: startFetch.status,
-    url: startFetch.url,
-    ok: startFetch.ok,
-    headers: startFetch.headers,
-    redirected: startFetch.redirected,
-  };
-
-  if (/^application\/json/.test(startFetch.headers.get("content-type"))) {
-    data.data = await startFetch.json();
-  }
-
-  return await data;
+  return await handleResponse(response);
 }

--- a/src/browser/post.js
+++ b/src/browser/post.js
@@ -1,4 +1,4 @@
-import { makeUrl, parseHeaders } from "../template/help";
+import { makeUrl, parseHeaders, handleResponse } from "../template/help";
 
 export default async function post(chunks, ...interpolations) {
   const url = makeUrl(chunks, interpolations, true);
@@ -10,24 +10,11 @@ export default async function post(chunks, ...interpolations) {
     headers["Content-Type"] = "application/json";
   }
 
-  const startFetch = await fetch(pureUrl, {
+  const response = await fetch(pureUrl, {
     method: "POST",
     body: postData,
     headers: headers,
   });
 
-  let data = {
-    data: null,
-    statusText: startFetch.statusText,
-    status: startFetch.status,
-    url: startFetch.url,
-    ok: startFetch.ok,
-    headers: startFetch.headers,
-  };
-
-  if (/^application\/json/.test(startFetch.headers.get("content-type"))) {
-    data.data = await startFetch.json();
-  }
-
-  return await data;
+  return await handleResponse(response);
 }

--- a/src/node/get.js
+++ b/src/node/get.js
@@ -1,25 +1,14 @@
-import { makeUrl, parseHeaders } from "../template/help";
+import { makeUrl, parseHeaders, handleResponse } from "../template/help";
 import fetch from "node-fetch";
 
 export default async function get(chunks, ...interpolations) {
   const url = makeUrl(chunks, interpolations);
   const { headers, pureUrl } = parseHeaders(url);
 
-  const startFetch = await fetch(pureUrl, {
+  const response = await fetch(pureUrl, {
     method: "GET",
     headers: headers,
   });
-  let data = {
-    data: null,
-    statusText: startFetch.statusText,
-    status: startFetch.status,
-    url: startFetch.url,
-    ok: startFetch.ok,
-    headers: startFetch.headers,
-    redirected: startFetch.redirected,
-  };
-  if (/^application\/json/.test(startFetch.headers.get("content-type"))) {
-    data.data = await startFetch.json();
-  }
-  return await data;
+
+  return await handleResponse(response);
 }

--- a/src/node/post.js
+++ b/src/node/post.js
@@ -1,4 +1,4 @@
-import { makeUrl, parseHeaders } from "../template/help";
+import { makeUrl, parseHeaders, handleResponse } from "../template/help";
 import fetch from "node-fetch";
 
 export default async function post(chunks, ...interpolations) {
@@ -14,23 +14,11 @@ export default async function post(chunks, ...interpolations) {
     }
   }
 
-  const startFetch = await fetch(pureUrl, {
+  const response = await fetch(pureUrl, {
     method: "POST",
     body: postData,
     headers: headers,
   });
 
-  let data = {
-    data: null,
-    statusText: startFetch.statusText,
-    status: startFetch.status,
-    url: startFetch.url,
-    ok: startFetch.ok,
-    headers: startFetch.headers,
-  };
-  if (/^application\/json/.test(startFetch.headers.get("content-type"))) {
-    data.data = await startFetch.json();
-  }
-
-  return await data;
+  return await handleResponse(response);
 }

--- a/src/template/help.js
+++ b/src/template/help.js
@@ -69,4 +69,13 @@ function parseHeaders(url) {
   return { headers, pureUrl };
 }
 
-export { generateFromObject, makeUrl, parseHeaders };
+async function handleResponse(response) {
+  if (/^application\/json/.test(response.headers.get("content-type"))) {
+    const data = await response.json();
+    return { response, data };
+  }
+
+  return response;
+}
+
+export { generateFromObject, makeUrl, parseHeaders, handleResponse };

--- a/test/browser/get.js
+++ b/test/browser/get.js
@@ -4,9 +4,9 @@ import { get } from "../../build/browser/index.umd.js";
 
 test("Get JSON without interpolating expressions", async t => {
   t.plan(2);
-  const data = await get`https://jsonplaceholder.typicode.com/todos/1`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Object);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/todos/1`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Object);
 });
 
 test("Get JSON with interpolating expressions (numeric value)", async t => {
@@ -14,9 +14,9 @@ test("Get JSON with interpolating expressions (numeric value)", async t => {
 
   const todoId = 1;
 
-  const data = await get`https://jsonplaceholder.typicode.com/todos/${todoId}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Object);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/todos/${todoId}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Object);
 });
 
 test("Get JSON with an interpolation expression (object value, List of URL request parameters)", async t => {
@@ -26,9 +26,9 @@ test("Get JSON with an interpolation expression (object value, List of URL reque
     postId: 3,
   };
 
-  const data = await get`http://jsonplaceholder.typicode.com/comments?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`http://jsonplaceholder.typicode.com/comments?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });
 
 test("Get JSON with an interpolation expression (object value, List of URL request parameters) #2", async t => {
@@ -38,9 +38,9 @@ test("Get JSON with an interpolation expression (object value, List of URL reque
     postId: 3,
   };
   const path = "albums";
-  const data = await get`http://jsonplaceholder.typicode.com/${path}?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`http://jsonplaceholder.typicode.com/${path}?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });
 
 test("Get JSON with interpolation expression (numeric value, string value)", async t => {
@@ -51,7 +51,7 @@ test("Get JSON with interpolation expression (numeric value, string value)", asy
   };
   const path = "albums";
   const id = 3;
-  const data = await get`https://jsonplaceholder.typicode.com/${path}/${id}/comments?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/${path}/${id}/comments?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });

--- a/test/browser/post.js
+++ b/test/browser/post.js
@@ -11,11 +11,11 @@ test("Creating a resource in jsonplaceholder. (Content-Type)", async t => {
       body: "bar",
       userId: Math.random(),
     };
-    const data = await post`https://jsonplaceholder.typicode.com/posts
+    const { response, data } = await post`https://jsonplaceholder.typicode.com/posts
     Content-type: application/json
     ${JSON.stringify(_post)}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -25,13 +25,13 @@ test("Creating a resource in jsonplaceholder.", async t => {
   t.plan(2);
 
   try {
-    const data = await post`https://jsonplaceholder.typicode.com/posts ${{
+    const {response, data } = await post`https://jsonplaceholder.typicode.com/posts ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -41,13 +41,13 @@ test("Creating a resource in jsonplaceholder with expression interpolations", as
   t.plan(2);
   const sub = "jsonplaceholder";
   try {
-    const data = await post`https://${sub}.${"typicode"}.com/${"posts"}/ ${{
+    const { response, data } = await post`https://${sub}.${"typicode"}.com/${"posts"}/ ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -56,13 +56,13 @@ test("Creating a resource in jsonplaceholder with expression interpolations", as
 test("Creating a basic resource in jsonplaceholder", async t => {
   t.plan(2);
   try {
-    const data = await post`https://jsonplaceholder.typicode.com/posts/ ${{
+    const { response, data } = await post`https://jsonplaceholder.typicode.com/posts/ ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }

--- a/test/node/get.js
+++ b/test/node/get.js
@@ -3,9 +3,9 @@ import { get } from "../../build/node/index.js";
 
 test("Get JSON without interpolating expressions", async t => {
   t.plan(2);
-  const data = await get`https://jsonplaceholder.typicode.com/todos/1`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Object);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/todos/1`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Object);
 });
 
 test("Get JSON with interpolating expressions (numeric value)", async t => {
@@ -13,9 +13,9 @@ test("Get JSON with interpolating expressions (numeric value)", async t => {
 
   const todoId = 1;
 
-  const data = await get`https://jsonplaceholder.typicode.com/todos/${todoId}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Object);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/todos/${todoId}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Object);
 });
 
 test("Get JSON with an interpolation expression (object value, List of URL request parameters)", async t => {
@@ -25,9 +25,9 @@ test("Get JSON with an interpolation expression (object value, List of URL reque
     postId: 3,
   };
 
-  const data = await get`http://jsonplaceholder.typicode.com/comments?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`http://jsonplaceholder.typicode.com/comments?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });
 
 test("Get JSON with an interpolation expression (object value, List of URL request parameters) #2", async t => {
@@ -37,9 +37,9 @@ test("Get JSON with an interpolation expression (object value, List of URL reque
     postId: 3,
   };
   const path = "albums";
-  const data = await get`http://jsonplaceholder.typicode.com/${path}?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`http://jsonplaceholder.typicode.com/${path}?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });
 
 test("Get JSON with interpolation expression (numeric value, string value)", async t => {
@@ -50,7 +50,7 @@ test("Get JSON with interpolation expression (numeric value, string value)", asy
   };
   const path = "albums";
   const id = 3;
-  const data = await get`https://jsonplaceholder.typicode.com/${path}/${id}/comments?${settings}`;
-  t.is(data.status, 200);
-  t.is(data.data.constructor, Array);
+  const { response, data } = await get`https://jsonplaceholder.typicode.com/${path}/${id}/comments?${settings}`;
+  t.is(response.status, 200);
+  t.is(data.constructor, Array);
 });

--- a/test/node/post.js
+++ b/test/node/post.js
@@ -11,11 +11,11 @@ test("Creating a resource in jsonplaceholder. (Content-Type)", async t => {
       body: "bar",
       userId: Math.random(),
     };
-    const data = await post`https://jsonplaceholder.typicode.com/posts
+    const { response, data } = await post`https://jsonplaceholder.typicode.com/posts
     Content-type: application/json
     ${JSON.stringify(_post)}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -25,13 +25,13 @@ test("Creating a resource in jsonplaceholder.", async t => {
   t.plan(2);
 
   try {
-    const data = await post`https://jsonplaceholder.typicode.com/posts ${{
+    const { response, data } = await post`https://jsonplaceholder.typicode.com/posts ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -41,13 +41,13 @@ test("Creating a resource in jsonplaceholder with expression interpolations", as
   t.plan(2);
   const sub = "jsonplaceholder";
   try {
-    const data = await post`https://${sub}.${"typicode"}.com/${"posts"}/ ${{
+    const { response, data } = await post`https://${sub}.${"typicode"}.com/${"posts"}/ ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }
@@ -56,13 +56,13 @@ test("Creating a resource in jsonplaceholder with expression interpolations", as
 test("Creating a basic resource in jsonplaceholder", async t => {
   t.plan(2);
   try {
-    const data = await post`https://jsonplaceholder.typicode.com/posts/ ${{
+    const { response, data } = await post`https://jsonplaceholder.typicode.com/posts/ ${{
       title: "foo",
       body: "bar",
       userId: Math.random(),
     }}`;
-    t.is(data.status, 201);
-    t.is(data.data.constructor, Object);
+    t.is(response.status, 201);
+    t.is(data.constructor, Object);
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
**Proposal**: Handle all get and post responses through a single `handleResponse` helper function, which returns an object with a `response` property, and optional `data`, can easily be [destructured](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Object_destructuring):
```javascript
// just the fetch response
const { response } = await get`http://example.com/ping`;
if (response.ok) {
  console.log('ping sucess!');
}
```
with data:
```javascript
const { response, data } = await get`http://example.com/something`;
if (response.ok) {
  console.log('got something', data);
}
```
